### PR TITLE
ENH: Start de-coupling models and views

### DIFF
--- a/pyxrf/gui.py
+++ b/pyxrf/gui.py
@@ -107,14 +107,27 @@ def run():
     app = QtApplication()
     defaults = get_defaults()
 
-    xrfview = XRFGui()
-    xrfview.io_model = FileIOModel(**defaults)
-    xrfview.param_model = GuessParamModel(**defaults)
-    xrfview.plot_model = LinePlotModel()
-    xrfview.img_model = DrawImage()
-    xrfview.fit_model = Fit1D(**defaults)
-    xrfview.setting_model = SettingModel()
-    xrfview.img_model_adv = DrawImageAdvanced()
+    io_model = FileIOModel(**defaults)
+    param_model = GuessParamModel(**defaults)
+    plot_model = LinePlotModel()
+    img_model = DrawImage()
+    fit_model = Fit1D(**defaults)
+    setting_model = SettingModel()
+    img_model_adv = DrawImageAdvanced()
+
+    # send working directory changes to the fit_model
+    io_model.observe('working_directory', fit_model.result_folder_changed)
+    io_model.observe('output_directory', fit_model.result_folder_changed)
+    io_model.observe('output_directory', param_model.result_folder_changed)
+
+
+    xrfview = XRFGui(io_model=io_model,
+                     param_model=param_model,
+                     plot_model=plot_model,
+                     img_model=img_model,
+                     fit_model=fit_model,
+                     setting_model=setting_model,
+                     img_model_adv=img_model_adv)
 
     xrfview.show()
     app.start()

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -69,6 +69,7 @@ class FileIOModel(Atom):
         Dict has filename as key and group data as value.
     """
     working_directory = Str()
+    output_directory = Str()
     data_file = Str()
     file_names = List()
     file_path = Str()
@@ -84,14 +85,25 @@ class FileIOModel(Atom):
     data_sets_fit = Typed(OrderedDict)
 
     def __init__(self,
-                 working_directory=None,
+                 working_directory=None, output_directory=None,
                  data_file=None, *args, **kwargs):
         if working_directory is None:
             working_directory = os.path.expanduser('~')
 
+        if output_directory is None:
+            output_directory = working_directory
+
+        self.working_directory = working_directory
+        self.output_directory = output_directory
+
         with self.suppress_notifications():
-            self.working_directory = working_directory
             self.data_file = data_file
+
+    @observe('working_directory')
+    def working_directory_changed(self, changed):
+        # make sure that the output directory stays in sync with working
+        # directory changes
+        self.output_directory = self.working_directory
 
     @observe('file_names')
     def update_more_data(self, change):

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -104,6 +104,19 @@ class Fit1D(Atom):
         self.result_folder = kwargs['working_directory']
         self.all_strategy = OrderedDict()
 
+    def result_folder_changed(self, changed):
+        """
+        Observer function to be connected to the fileio model in the top-level
+        gui.py startup
+
+        Parameters
+        ----------
+        changed : dict
+            This is the dictionary that gets passed to a function with the
+            @observe decorator
+        """
+        self.result_folder = changed['value']
+
     @observe('selected_element')
     def _selected_element_changed(self, changed):
         element = self.selected_element.split('_')[0]

--- a/pyxrf/model/guessparam.py
+++ b/pyxrf/model/guessparam.py
@@ -428,6 +428,19 @@ class GuessParamModel(Atom):
                 temp_dict.update({e: ps})
         self.EC.add_to_dict(temp_dict)
 
+    def result_folder_changed(self, changed):
+        """
+        Observer function to be connected to the fileio model in the top-level
+        gui.py startup
+
+        Parameters
+        ----------
+        changed : dict
+            This is the dictionary that gets passed to a function with the
+            @observe decorator
+        """
+        self.result_folder = changed['value']
+
     @observe('file_opt')
     def choose_file(self, change):
         if self.file_opt == 0:

--- a/pyxrf/view/fileio.enaml
+++ b/pyxrf/view/fileio.enaml
@@ -80,7 +80,6 @@ enamldef FileView(DockItem): file_view:
                     path = FileDialogEx.get_existing_directory(file_view)
                     if path:
                         io_model.working_directory = path
-                        fit_model.result_folder = path
             Field: folder_fd:
                 text := io_model.working_directory
             PushButton: files_btn:
@@ -128,11 +127,10 @@ enamldef FileView(DockItem): file_view:
                 clicked ::
                     path = FileDialogEx.get_existing_directory(file_view)
                     if path:
-                        param_model.result_folder = path
-                        fit_model.result_folder = path
+                        io_model.output_directory = path
                         fd_out.text = path
             Field: fd_out:
-                text << fit_model.result_folder
+                text << io_model.output_directory
 
             #Label: name_lb:
             #    text = ''


### PR DESCRIPTION
These changes are the start of trying to keep a 1:1 model:view relationship.  Models should not need *too* many parameters from each other.  The ones that do need to be passed around should be done via the **Observer** pattern which can be seen in pyxrf/gui.py lines 119-121.