### PR TITLE
MNT: import handlers from hxntools/bs branch

### DIFF
--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -53,17 +53,14 @@ import logging
 logger = logging.getLogger(__name__)
 
 try:
-    #from dataportal import DataBroker as db
-    #from dataportal import StepScan as ss
-    #from dataportal import DataMuxer as dm
     from databroker.databroker import DataBroker as db, get_table
     # registers a filestore handler for the XSPRESS3 detector
-    from hxntools import detectors as hxndetectors
+    from hxntools import handlers as hxn_handlers
 except ImportError, e:
     db = None
     ss = None
     dm = None
-    logger.warning('dataportal and hxntools are not available: %s' % (e))
+    logger.error('dataportal and hxntools are not available: %s' % (e))
 
 
 class FileIOModel(Atom):

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -56,11 +56,9 @@ try:
     from databroker.databroker import DataBroker as db, get_table
     # registers a filestore handler for the XSPRESS3 detector
     from hxntools import handlers as hxn_handlers
-except ImportError, e:
+except ImportError as e:
     db = None
-    ss = None
-    dm = None
-    logger.error('dataportal and hxntools are not available: %s' % (e))
+    logger.error('databroker and hxntools are not available: %s', e)
 
 
 class FileIOModel(Atom):
@@ -137,11 +135,11 @@ class FileIOModel(Atom):
         """
         Load data according to runID number.
 
-        requires dataportal
+        requires databroker
         """
         if db is None:
-            raise RuntimeError("dataportal is not installed. This function "
-                               "is disabled.  To install dataportal, see "
+            raise RuntimeError("databroker is not installed. This function "
+                               "is disabled.  To install databroker, see "
                                "https://nsls-ii.github.io/install.html")
         if self.h_num != 0 and self.v_num != 0:
             datashape = [self.v_num, self.h_num]
@@ -286,7 +284,7 @@ def fetch_data_from_db(runid):
     """
     Read data from database.
 
-    .. note:: Requires the dataportal package from NSLS2
+    .. note:: Requires the databroker package from NSLS2
 
     Parameters
     ----------
@@ -326,7 +324,7 @@ def read_runid(runid, c_list, dshape=None):
     """
     Read data from databroker.
 
-    .. note:: Requires the dataportal package from NSLS2
+    .. note:: Requires the databroker package from NSLS2
 
     .. note:: Not currently used in the gui
 
@@ -1332,7 +1330,7 @@ def db_to_hdf(fpath, runid,
     """
     Read data from databroker, and save the data to hdf file.
 
-    .. note:: Requires the dataportal package from NSLS2
+    .. note:: Requires the databroker package from NSLS2
     .. note:: This should probably be moved to suitcase!
 
     Parameters
@@ -1434,7 +1432,7 @@ def make_hdf(fpath, runid, datashape, config_file=False):
     """
     Assume data is ready from databroker, so save the data to hdf file.
 
-    .. note:: Requires the dataportal package from NSLS2
+    .. note:: Requires the databroker package from NSLS2
 
     Parameters
     ----------

--- a/pyxrf/view/fileio.enaml
+++ b/pyxrf/view/fileio.enaml
@@ -48,9 +48,9 @@ from enaml.stdlib.fields import IntField as DefaultIntField
 import numpy as np
 
 try:
-    import dataportal
+    import databroker
 except ImportError:
-    dataportal = None
+    databroker = None
 
 enamldef IntField(DefaultIntField):
     submit_triggers = ['auto_sync'] #['return_pressed']
@@ -169,7 +169,7 @@ enamldef FileView(DockItem): file_view:
                     value := io_model.runid
 
                 PushButton: load_btn:
-                    enabled = dataportal is not None
+                    enabled = databroker is not None
                     text = "Load Data from Database"
                     clicked ::
                         io_model.load_data_runid()


### PR DESCRIPTION
Now using bluesky branch of hxntools, where the handler is separate from the detector class.

New hxntools loads full hdf5 spectra into memory if possible - 200x200 scans now load/save with `fio.make_hdf` in less than 3 minutes.

I've also updated the `li_ophyd_new` environment for the xf03id user to this new version.